### PR TITLE
fix width enum for Filament 4 compatibility

### DIFF
--- a/src/Livewire/ConsentOptionFormBuilder.php
+++ b/src/Livewire/ConsentOptionFormBuilder.php
@@ -10,7 +10,7 @@ use Filament\Forms\Get;
 use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
-use Filament\Support\Enums\MaxWidth;
+use Filament\Support\Enums\Width;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\HtmlString;
@@ -45,9 +45,9 @@ class ConsentOptionFormBuilder extends SimplePage implements Forms\Contracts\Has
         return false;
     }
 
-    public function getMaxWidth(): MaxWidth
+    public function getMaxWidth(): Width|string|null
     {
-        return MaxWidth::FiveExtraLarge;
+        return Width::FiveExtraLarge;
     }
 
     public function mount(): void


### PR DESCRIPTION
## Summary
- update Filament width enum usage after upgrading to v4

## Testing
- `composer install` *(fails: Root composer.json requires nunomaduro/collision ^7.9 -> found v8 but it conflicts)*
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4abf2ec6483338c0922028b139399