### PR TITLE
chore: update for filament v4 schema

### DIFF
--- a/src/Livewire/ConsentOptionFormBuilder.php
+++ b/src/Livewire/ConsentOptionFormBuilder.php
@@ -3,10 +3,10 @@
 namespace Visualbuilder\FilamentUserConsent\Livewire;
 
 use Filament\Forms;
-use Filament\Forms\Components\Section;
+use Filament\Schemas\Components\Section;
 use Filament\Forms\Concerns\InteractsWithForms;
-use Filament\Forms\Form;
-use Filament\Forms\Get;
+use Filament\Schemas\Schema;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
@@ -86,10 +86,10 @@ class ConsentOptionFormBuilder extends SimplePage implements Forms\Contracts\Has
         $this->form->fill($fillData);
     }
 
-    public function form(Form $form): Form
+    public function form(Schema $schema): Schema
     {
-        return $form
-            ->schema($this->getFormSchema())
+        return $schema
+            ->components($this->getFormSchema())
             ->model($this->getFormModel())
             ->statePath('data')
             ->operation($this->getFormContext());

--- a/src/Livewire/ConsentOptionPreview.php
+++ b/src/Livewire/ConsentOptionPreview.php
@@ -7,15 +7,15 @@ use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Radio;
-use Filament\Forms\Components\Section;
+use Filament\Schemas\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Visualbuilder\FilamentUserConsent\Models\ConsentOption;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
-use Filament\Forms\Form;
-use Filament\Forms\Get;
+use Filament\Schemas\Schema;
+use Filament\Schemas\Components\Utilities\Get;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 use Livewire\Component;
@@ -58,10 +58,10 @@ class ConsentOptionPreview extends Component implements HasForms
         $this->form->fill($fillData);
     }
 
-    public function form(Form $form)
+    public function form(Schema $schema): Schema
     {
         $formInputs = $this->getFormSchema();
-        return $form->schema($formInputs)
+        return $schema->components($formInputs)
         ->statePath('data');
     }
 

--- a/src/Resources/ConsentOptionResource.php
+++ b/src/Resources/ConsentOptionResource.php
@@ -2,15 +2,15 @@
 
 namespace Visualbuilder\FilamentUserConsent\Resources;
 
-use Filament\Forms\Components\Livewire;
+use Filament\Schemas\Components\Livewire;
 use Closure;
 use Filament\Forms;
-use Filament\Forms\Components\Group;
+use Filament\Schemas\Components\Group;
 use Filament\Forms\Components\Repeater;
-use Filament\Forms\Components\Section;
-use Filament\Forms\Form;
-use Filament\Forms\Get;
-use Filament\Forms\Set;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Tables;
@@ -66,12 +66,12 @@ class ConsentOptionResource extends Resource
         return config('filament-user-consent.navigation.consent_options.register');
     }
 
-    public static function form(Form $form): Form
+    public static function form(Schema $schema): Schema
     {
-        return $form
-            ->schema([
-                Section::make('')->schema([
-                    Group::make()->schema([
+        return $schema
+            ->components([
+                Section::make('')->components([
+                    Group::make()->components([
                         Forms\Components\TextInput::make('title')
                             ->live()
                             ->afterStateUpdated(
@@ -142,7 +142,7 @@ class ConsentOptionResource extends Resource
                         ->columnSpanFull(),
 
                 ])->columns(3),
-                Section::make('Additional Info')->schema([
+                Section::make('Additional Info')->components([
 
                     Repeater::make('fields')->label('')
                     ->schema([

--- a/src/Resources/ConsentOptionResource/RelationManagers/ConsentOptionQuestionsRelationManager.php
+++ b/src/Resources/ConsentOptionResource/RelationManagers/ConsentOptionQuestionsRelationManager.php
@@ -6,9 +6,9 @@ use App\Models\SurveyQuestionType;
 use Closure;
 use Filament\Forms;
 use Filament\Forms\Components\Repeater;
-use Filament\Forms\Components\Section;
-use Filament\Forms\Form;
-use Filament\Forms\Get;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -20,11 +20,11 @@ class ConsentOptionQuestionsRelationManager extends RelationManager
 {
     protected static string $relationship = 'questions';
 
-    public function form(Form $form): Form
+    public function form(Schema $schema): Schema
     {
-        return $form
-            ->schema([
-                Section::make()->schema([
+        return $schema
+            ->components([
+                Section::make()->components([
                     Forms\Components\Select::make('component')
                         ->required()
                         ->options(config('filament-user-consent.components'))
@@ -56,7 +56,7 @@ class ConsentOptionQuestionsRelationManager extends RelationManager
                         ->inline(false)
                         ->visible(fn(Get $get) => $get('component') !== 'placeholder'),
                 ])->columns(3),
-                Section::make()->schema([
+                Section::make()->components([
                     Repeater::make('options')
                         ->relationship()
                         ->schema([
@@ -81,7 +81,7 @@ class ConsentOptionQuestionsRelationManager extends RelationManager
                         ->orderColumn('sort')
                         ->columns(2)
                 ])->visible(fn (Get $get) => in_array($get('component'), ['likert', 'select', 'radio', 'check'])),
-                Section::make()->schema([
+                Section::make()->components([
                     TinyEditor::make('content')
                         ->label("HTML Content")
                         ->profile('default')

--- a/src/Resources/ConsentOptionResponseResource.php
+++ b/src/Resources/ConsentOptionResponseResource.php
@@ -2,7 +2,7 @@
 
 namespace Visualbuilder\FilamentUserConsent\Resources;
 
-use Filament\Forms\Form;
+use Filament\Schemas\Schema;
 use Filament\Infolists\Components\Grid as ComponentsGrid;
 use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\Section;
@@ -57,10 +57,10 @@ class ConsentOptionResponseResource extends Resource
         return config('filament-user-consent.navigation.consent_responses.register');
     }
 
-    public static function form(Form $form): Form
+    public static function form(Schema $schema): Schema
     {
-        return $form
-            ->schema([
+        return $schema
+            ->components([
 
             ]);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,10 +7,10 @@ use BladeUI\Icons\BladeIconsServiceProvider;
 use Filament\Actions\ActionsServiceProvider;
 use Filament\FilamentServiceProvider;
 use Filament\Forms\FormsServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
 use Filament\Infolists\InfolistsServiceProvider;
 use Filament\Notifications\NotificationsServiceProvider;
 use Filament\SpatieLaravelSettingsPluginServiceProvider;
-use Filament\SpatieLaravelTranslatablePluginServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
@@ -50,11 +50,11 @@ class TestCase extends Orchestra
             BladeIconsServiceProvider::class,
             FilamentServiceProvider::class,
             FormsServiceProvider::class,
+            SchemasServiceProvider::class,
             InfolistsServiceProvider::class,
             LivewireServiceProvider::class,
             NotificationsServiceProvider::class,
             SpatieLaravelSettingsPluginServiceProvider::class,
-            SpatieLaravelTranslatablePluginServiceProvider::class,
             SupportServiceProvider::class,
             TablesServiceProvider::class,
             WidgetsServiceProvider::class,


### PR DESCRIPTION
## Summary
- migrate resource forms to Filament v4 `Schema` API
- update Livewire forms and relation manager imports
- register Schemas service provider in tests

## Testing
- `composer test` *(fails: Class "Filament\SpatieLaravelTranslatablePluginServiceProvider" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c94160f083339eac5e347de78600