### PR TITLE
chore: allow laravel 13 (testbench ^11) and cover it in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,15 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.3, 8.4]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpunit/phpunit": "^12.0",
         "barryvdh/laravel-ide-helper": "^3.1",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",
         "pestphp/pest-plugin-livewire": "^4.0",


### PR DESCRIPTION
Part of the Laravel 13 readiness sweep across visualbuilder packages (neurobox NB-2860 groundwork).

Constraint widening only — no behaviour changes. Suite verified locally on laravel/framework **v13.19.0**: 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)